### PR TITLE
Fix 404 error for API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Audius API Documentation
 
-[https://audius-project.github.io/api-docs](https://audius-project.github.io/api-docs)
+[https://audiusproject.github.io/api-docs](https://audiusproject.github.io/api-docs)
 
 
 Getting started:


### PR DESCRIPTION
The API docs currently 404, this fixes that with the correct URL.