### PR TITLE
Remove separated enums table in favor of inlining the values

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -442,6 +442,21 @@ html, body {
     }
   }
 
+  table.inline {
+    margin: 0.5em -5px;
+    border-spacing: 5px;
+    border-collapse: separate;
+    font-size: 0.9em;
+
+    th {
+      padding: 5px 5px 5px 0px;
+    }
+    tr>td {
+      padding: 4px 12px;
+      background-color: lighten($main-bg,8.6%);
+    }
+  }
+
   dt {
     font-weight: bold;
   }

--- a/swagger/templates/operation.dot
+++ b/swagger/templates/operation.dot
@@ -25,7 +25,10 @@
 
 {{? data.operation.summary && !data.options.tocSummary}}*{{= data.operation.summary }}*{{?}}
 
-{{? data.operation.description}}{{= data.operation.description }}{{?}}
+{{ const linkify = (text) => {
+    return text.replace(/(https?\:\/\/[^\s]*)/g, '<a target="_blank" href="$1">$1</a>')
+}; }}
+{{? data.operation.description}}{{= linkify(data.operation.description) }}{{?}}
 
 {{? data.operation.requestBody}}
 > Body parameter

--- a/swagger/templates/parameters.def
+++ b/swagger/templates/parameters.def
@@ -2,8 +2,8 @@
 <h3 id="{{=data.operationUniqueSlug}}-parameters">Query Parameters</h3>
 
 |Name|Type|Required|Description|
-|---|---|---|---|---|
-{{~ data.parameters :p}}|{{=p.name}}|{{=p.safeType}}|{{=p.required}}|{{=p.shortDesc || 'none'}}|
+|---|---|---|---|---|---|
+{{~ data.parameters :p}}|{{=p.name}}|{{=p.safeType}}|{{=p.required}}|{{=p.shortDesc || 'none'}}{{? p.schema && p.schema.enum}}<table class="inline"><tr><th>Available values:</th>{{~ p.schema.enum :e}}<td>{{=e}}</td>{{~}}</tr></table>{{?}}|
 {{~}}
 
 {{? data.longDescs }}
@@ -14,12 +14,6 @@
 {{?}}
 
 {{~ data.parameters :p}}
-
-{{? p.schema && p.schema.enum }}
-{{~ p.schema.enum :e}}
-{{ var entry = {}; entry.name = p.name; entry.value = e; data.enums.push(entry); }}
-{{~}}
-{{?}}
 
 {{? p.schema && p.schema.items && p.schema.items.enum }}
 {{~ p.schema.items.enum :e}}


### PR DESCRIPTION
Inlines the enum values to the parameter tables to clean up the extra table.

Before:
![image](https://user-images.githubusercontent.com/3690498/162155764-5bb1c25c-ebd7-4147-bb19-8ede818e090a.png)

After:
![image](https://user-images.githubusercontent.com/3690498/162155660-a6f3e2ea-32a4-4c59-8fe4-e9e93edb9d7f.png)
